### PR TITLE
[Doppins] Upgrade dependency Django to ==1.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.10.6
+Django==1.11
 graphene_django==1.2.1


### PR DESCRIPTION
Hi!

A new version was just released of `Django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded Django from `==1.10.6` to `==1.11`

