### PR TITLE
[Doppins] Upgrade dependency react-dom to 15.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "electron": "1.6.2",
     "electron-reload": "^1.1.0",
     "react": "15.4.2",
-    "react-dom": "15.5.0",
+    "react-dom": "15.5.1",
     "wav": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `react-dom`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-dom from `15.4.2` to `15.5.0`

