### PR TITLE
[Doppins] Upgrade dependency react-addons-test-utils to 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "jest-css-modules": "^1.1.0",
     "json-loader": "0.5.4",
     "postcss-loader": "1.3.3",
-    "react-addons-test-utils": "15.4.2",
+    "react-addons-test-utils": "15.5.0",
     "react-hot-loader": "3.0.0-beta.6",
     "react-svg-loader": "1.1.1",
     "sinon": "2.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `react-addons-test-utils`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded react-addons-test-utils from `15.4.2` to `15.5.0`

#### Changelog:

#### Version 15.5.0
## 15.5.0 (April 7, 2017)

### React

* Added a deprecation warning for `React.createClass`. Points users to create-react-class instead. (`@acdlite`](https://github.com/acdlite) in [d9a4fa4 (`https://github.com/facebook/react/commit/d9a4fa4f51c6da895e1655f32255cf72c0fe620e`))
* Added a deprecation warning for `React.PropTypes`. Points users to prop-types instead. (`@acdlite`](https://github.com/acdlite) in [043845c (`https://github.com/facebook/react/commit/043845ce75ea0812286bbbd9d34994bb7e01eb28`))
* Fixed an issue when using `ReactDOM` together with `ReactDOMServer`. (`@wacii`](https://github.com/wacii) in [`#9005` (`https://github.com/facebook/react/pull/9005`))
* Fixed issue with Closure Compiler. (`@anmonteiro`](https://github.com/anmonteiro) in [`#8895` (`https://github.com/facebook/react/pull/8895`))
* Another fix for Closure Compiler. (`@Shastel`](https://github.com/Shastel) in [`#8882` (`https://github.com/facebook/react/pull/8882`))
* Added component stack info to invalid element type warning. (`@n3tr`](https://github.com/n3tr) in [`#8495` (`https://github.com/facebook/react/pull/8495`))

### React DOM

* Fixed Chrome bug when backspacing in number inputs. (`@nhunzaker`](https://github.com/nhunzaker) in [`#7359` (`https://github.com/facebook/react/pull/7359`))
* Added `react-dom/test-utils`, which exports the React Test Utils. ([`@bvaughn`](https://github.com/bvaughn))

### React Test Renderer

* Fixed bug where `componentWillUnmount` was not called for children. (`@gre`](https://github.com/gre) in [`#8512` (`https://github.com/facebook/react/pull/8512`))
* Added `react-test-renderer/shallow`, which exports the shallow renderer. ([`@bvaughn`](https://github.com/bvaughn))

### React Addons

* Last release for addons; they will no longer be actively maintained.
* Removed `peerDependencies` so that addons continue to work indefinitely. (`@acdlite`](https://github.com/acdlite) and [`@bvaughn`](https://github.com/bvaughn) in [8a06cd7](`https://github.com/facebook/react/commit/8a06cd7a786822fce229197cac8125a551e8abfa`) and [67a8db3 (`https://github.com/facebook/react/commit/67a8db3650d724a51e70be130e9008806402678a`))
* Updated to remove references to `React.createClass` and `React.PropTypes` (`@acdlite`](https://github.com/acdlite) in [12a96b9 (`https://github.com/facebook/react/commit/12a96b94823d6b6de6b1ac13bd576864abd50175`))
* `react-addons-test-utils` is deprecated. Use `react-dom/test-utils` and `react-test-renderer/shallow` instead. ([`@bvaughn`](https://github.com/bvaughn))

