### PR TITLE
[Doppins] Upgrade dependency electron-webpack-plugin to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "css-loader": "0.28.0",
     "electron-packager": "8.6.0",
     "electron-rebuild": "1.5.7",
-    "electron-webpack-plugin": "1.2.2",
+    "electron-webpack-plugin": "2.0.0",
     "enzyme": "2.8.0",
     "enzyme-to-json": "1.5.0",
     "eslint": "3.19.0",


### PR DESCRIPTION
Hi!

A new version was just released of `electron-webpack-plugin`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded electron-webpack-plugin from `1.2.2` to `2.0.0`

