### PR TITLE
[Doppins] Upgrade dependency enzyme to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "electron-packager": "8.6.0",
     "electron-rebuild": "1.5.7",
     "electron-webpack-plugin": "2.0.0",
-    "enzyme": "2.8.0",
+    "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.0",
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",


### PR DESCRIPTION
Hi!

A new version was just released of `enzyme`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded enzyme from `2.8.0` to `2.8.1`

