### PR TITLE
[Doppins] Upgrade dependency electron to 1.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://valence.audio/",
   "dependencies": {
-    "electron": "1.3.15",
+    "electron": "1.6.5",
     "electron-reload": "1.1.0",
     "filter-obj": "1.1.0",
     "lodash.range": "3.2.0",


### PR DESCRIPTION
Hi!

A new version was just released of `electron`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded electron from `1.6.2` to `1.6.5`

#### Changelog:

#### Version 1.6.6
1.6.6 Release Notes (`https://github.com/electron/electron/releases/v1.6.6`)

#### Version 1.6.5
1.6.5 Release Notes (`https://github.com/electron/electron/releases/v1.6.5`)

#### Version 1.6.4
1.6.4 Release Notes (`https://github.com/electron/electron/releases/v1.6.4`)

#### Version 1.6.3
1.6.3 Release Notes (`https://github.com/electron/electron/releases/v1.6.3`)

