### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-react to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "eslint-plugin-jsdoc": "3.0.2",
     "eslint-plugin-jsx-a11y": "5.0.0",
     "eslint-plugin-prettier": "2.0.1",
-    "eslint-plugin-react": "6.10.3",
+    "eslint-plugin-react": "7.0.0",
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-react`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-react from `6.10.3` to `7.0.0`

#### Changelog:

#### Version 7.0.0
### Added
* Add `no-will-update-set-state` rule ([`#1139`][] `@ManThursday`)
* Add import and destructuring support to `no-deprecated`
* Add `reservedFirst` option to `jsx-sort-props` ([`#1134`][] `@MatthewHerbst`)

### Breaking
* Update rules for React 15.5.0:
  * Add warnings for `React.PropTypes` and `React.createClass` in `no-deprecated` ([`#1148`][] `@Calyhre`)
  * Update `createClass` component factory to `createReactClass`. This is used for React component detection, if you still using `React.createClass` use the [shared settings](README.md#configuration) to specify `createClass` as component factory
* Drop Node.js < 4 support ([`#1038`][] `@ljharb`)
* Add `no-danger-with-children` rule to recommended rules ([`#748`][] `@ljharb`)
* Add `no-string-refs` rule to recommended rules ([`#749`][] `@ljharb`)
* Add `jsx-key` rule to recommended rules ([`#750`][] `@ljharb`)
* Add `jsx-no-comment-textnodes` rule to recommended rules ([`#751`][] `@ljharb`)
* Add `jsx-no-target-blank` rule to recommended rules ([`#752`][] `@ljharb`)
* Add `no-unescaped-entities` rule to recommended rules ([`#841`][] `@ljharb`)
* Add `no-children-prop` rule to recommended rules ([`#842`][] `@ljharb`)
* Remove deprecated `wrap-multilines` rule, use `jsx-wrap-multilines` instead
* Remove deprecated `no-comment-textnodes` rule, use `jsx-no-comment-textnodes` instead
* Remove deprecated `require-extension` rule, use the eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) [`extensions` (`https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md`) rule instead
* Deprecate `jsx-space-before-closing` rule, use the `jsx-tag-spacing` rule instead. `jsx-space-before-closing` still works but will trigger a warning ([`#1070`][] `@afairb`)
* `jsx-first-prop-new-line` default is now `multiline-multiprop` ([`#802`][] `@kokarn`)
* `jsx-wrap-multilines` now checks arrow functions without block body. It can be deactivated in [rule options](docs/rules/jsx-wrap-multilines.md#rule-details) ([`#790`][] `@ColCh`)
* `jsx-no-undef` will not check the global scope by default. You can force it with the [`allowGlobals`](docs/rules/jsx-no-undef.md#allowglobals) option ([`#1013`][] `@jomasti`)

### Fixed
* Fix `no-unused-prop-types` false positive with `nextProps` ([`#1079`][] `@Kerumen`)
* Fix `prefer-stateless-function` to not warn on classes with decorators ([`#1034`][] `@benstepp`)

### Changed
* Update dependencies ([`#1119`][] `@danez`)
* Documentation improvements ([`#1121`][] `@omerzach`, [`#1130`][] `@dreid`, [`#1131`][] `@shoesandsocks`, [`#1149`][] `@Adzz`, [`#1151`][] `@MatthewHerbst`, [`#1167`][] `@Slumber86`)

[`#1134`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1134`
[`#1038`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1038`
[`#802`]: `https://github.com/yannickcr/eslint-plugin-react/pull/802`
[`#790`]: `https://github.com/yannickcr/eslint-plugin-react/issues/790`
[`#1013`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1013`
[`#1070`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1070`
[`#748`]: `https://github.com/yannickcr/eslint-plugin-react/issues/748`
[`#749`]: `https://github.com/yannickcr/eslint-plugin-react/issues/749`
[`#750`]: `https://github.com/yannickcr/eslint-plugin-react/issues/750`
[`#751`]: `https://github.com/yannickcr/eslint-plugin-react/issues/751`
[`#752`]: `https://github.com/yannickcr/eslint-plugin-react/issues/752`
[`#841`]: `https://github.com/yannickcr/eslint-plugin-react/issues/841`
[`#842`]: `https://github.com/yannickcr/eslint-plugin-react/issues/842`
[`#1139`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1139`
[`#1148`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1148`
[`#1079`]: `https://github.com/yannickcr/eslint-plugin-react/issues/1079`
[`#1034`]: `https://github.com/yannickcr/eslint-plugin-react/issues/1034`
[`#1119`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1119`
[`#1121`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1121`
[`#1130`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1130`
[`#1131`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1131`
[`#1149`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1149`
[`#1151`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1151`
[`#1167`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1167`

#### Version 7.0.0
### Added
* Add `reservedFirst` option to `jsx-sort-props` ([`#1134`] `@MatthewHerbst`)

### Breaking
* Drop Node.js < 4 support ([`#1038`] `@ljharb`)
* Add `no-danger-with-children` rule to recommended rules ([`#748`] `@ljharb`)
* Add `no-string-refs` rule to recommended rules ([`#749`] `@ljharb`)
* Add `jsx-key` rule to recommended rules ([`#750`] `@ljharb`)
* Add `jsx-no-comment-textnodes` rule to recommended rules ([`#751`] `@ljharb`)
* Add `jsx-no-target-blank` rule to recommended rules ([`#752`] `@ljharb`)
* Add `no-unescaped-entities` rule to recommended rules ([`#841`] `@ljharb`)
* Add `no-children-prop` rule to recommended rules ([`#842`] `@ljharb`)
* Remove deprecated `wrap-multilines` rule, use `jsx-wrap-multilines` instead
* Remove deprecated `no-comment-textnodes` rule, use `jsx-no-comment-textnodes` instead
* Remove deprecated `require-extension` rule, use the eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) [`extensions` (`https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md`) rule instead
* Deprecate `jsx-space-before-closing` rule, use the `jsx-tag-spacing` rule instead. `jsx-space-before-closing` still works but will trigger a warning ([`#1070`] `@afairb`)
* `jsx-first-prop-new-line` default is now `multiline-multiprop` ([`#802`] `@kokarn`)
* `jsx-wrap-multilines` now checks arrow functions without block body. It can be deactivated in [rule options](docs/rules/jsx-wrap-multilines.md#rule-details) ([`#790`] `@ColCh`)
* `jsx-no-undef` will not check the global scope by default. You can force it with the [`allowGlobals`](docs/rules/jsx-no-undef.md#allowglobals) option ([`#1013`] `@jomasti`)

[`#1134`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1134`
[`#1038`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1038`
[`#802`]: `https://github.com/yannickcr/eslint-plugin-react/pull/802`
[`#790`]: `https://github.com/yannickcr/eslint-plugin-react/issues/790`
[`#1013`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1013`
[`#1070`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1070`
[`#748`]: `https://github.com/yannickcr/eslint-plugin-react/issues/748`
[`#749`]: `https://github.com/yannickcr/eslint-plugin-react/issues/749`
[`#750`]: `https://github.com/yannickcr/eslint-plugin-react/issues/750`
[`#751`]: `https://github.com/yannickcr/eslint-plugin-react/issues/751`
[`#752`]: `https://github.com/yannickcr/eslint-plugin-react/issues/752`
[`#841`]: `https://github.com/yannickcr/eslint-plugin-react/issues/841`
[`#842`]: `https://github.com/yannickcr/eslint-plugin-react/issues/842`

#### Version 7.0.0
### Added
* Add `no-will-update-set-state` rule ([`#1139`] `@ManThursday`)
* Add import and destructuring support to `no-deprecated`

### Breaking
* Update rules for React 15.5.0:
  * Add warnings for `React.PropTypes` and `React.createClass` in `no-deprecated` ([`#1148`][] `@Calyhre`)
  * Update `createClass` component factory to `createReactClass`. This is used for React component detection, if you still using `React.createClass` use the [shared settings](README.md#configuration) to specify `createClass` as component factory

### Fixed
* Fix `no-unused-prop-types` false positive with `nextProps` ([`#1079`][] `@Kerumen`)
* Fix `prefer-stateless-function` to not warn on classes with decorators ([`#1034`][] `@benstepp`)

### Changed
* Update dependencies ([`#1119`][] `@danez`)
* Documentation improvements ([`#1121`][] `@omerzach`, [`#1130`][] `@dreid`, [`#1131`][] `@shoesandsocks`, [`#1149`][] `@Adzz`, [`#1151`][] `@MatthewHerbst`)

[`#1139`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1139`
[`#1148`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1148`
[`#1079`]: `https://github.com/yannickcr/eslint-plugin-react/issues/1079`
[`#1034`]: `https://github.com/yannickcr/eslint-plugin-react/issues/1034`
[`#1119`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1119`
[`#1121`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1121`
[`#1130`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1130`
[`#1131`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1131`
[`#1149`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1149`
[`#1151`]: `https://github.com/yannickcr/eslint-plugin-react/pull/1151`

