### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-jsx-a11y to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jest": "20.0.0",
     "eslint-plugin-jsdoc": "3.0.2",
-    "eslint-plugin-jsx-a11y": "5.0.0",
+    "eslint-plugin-jsx-a11y": "5.0.1",
     "eslint-plugin-prettier": "2.0.1",
     "eslint-plugin-react": "7.0.0",
     "eslint-plugin-security": "1.3.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-jsx-a11y`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-jsx-a11y from `5.0.0` to `5.0.1`

#### Changelog:

#### Version 5.0.1
Swapped `Array.includes` for `array-includes` polyfill to support node versions <4

