### PR TITLE
[Doppins] Upgrade dependency postcss-loader to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "jest-css-modules": "1.1.0",
     "json-loader": "0.5.4",
     "offline-plugin": "4.7.0",
-    "postcss-loader": "2.0.0",
+    "postcss-loader": "2.0.1",
     "postcss-svgo": "2.1.6",
     "prettier": "1.3.1",
     "react-addons-test-utils": "15.5.1",


### PR DESCRIPTION
Hi!

A new version was just released of `postcss-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded postcss-loader from `1.3.3` to `2.0.0`

