### PR TITLE
[Doppins] Upgrade dependency codecov to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "babel-preset-flow": "6.23.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
-    "codecov": "2.1.0",
+    "codecov": "2.2.0",
     "css-loader": "0.28.1",
     "dalek-cli": "0.0.5",
     "enzyme": "2.8.1",


### PR DESCRIPTION
Hi!

A new version was just released of `codecov`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded codecov from `2.1.0` to `2.2.0`

