### PR TITLE
[Doppins] Upgrade dependency jest to 20.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "html-webpack-plugin": "2.28.0",
     "husky": "0.13.3",
     "istanbul": "0.4.5",
-    "jest": "20.0.0",
+    "jest": "20.0.1",
     "jest-cli": "20.0.0",
     "jest-css-modules": "1.1.0",
     "json-loader": "0.5.4",


### PR DESCRIPTION
Hi!

A new version was just released of `jest`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded jest from `20.0.0` to `20.0.1`

