### PR TITLE
[Doppins] Upgrade dependency yarn to 0.24.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,6 @@
     "webpack": "2.5.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
-    "yarn": "0.23.4"
+    "yarn": "0.24.4"
   }
 }


### PR DESCRIPTION
Hi!

A new version was just released of `yarn`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded yarn from `0.23.4` to `0.24.4`

#### Changelog:

#### Version 0.25.1
* Fixed CI deployment script

#### Version 0.24.4
Fixes:
- Make `bin/yarn-bundle-entry.js` (`bin/yarn.js` in the tarball) executable
- Fix yarn "entrypoint" shell script (`#3362`)

#### Version 0.24.3
* Updates the prefix used for yarn-create packages; was `yarn-create-`, is now simply `create-`
* Adds a `enable-meta-folder` option to move the integrity file and possibly others into a common directory

#### Version 0.24.2
- Adds `yarn create`

#### Version 0.24.1
Same as 0.24.0, triggered a new release for CI

#### Version 0.24.0


* __Fix offline resolution (`#3311`)__

    [Maël Nison](mailto:nison.mael@gmail.com) - Thu, 4 May 2017 13:46:13 +0100



* __Add vendor informations to licences ls command (`#3292`)__

    [Matthias Lochbrunner](mailto:matthias_lochbrunner@web.de) - Wed, 3 May 2017 11:39:25 +0100



* __Correctly handle installationMethod when using bundled build (`#3113`)__

    [Daniel Lo Nigro](mailto:daniel@dan.cx) - Tue, 2 May 2017 15:29:36 +0100


* __Better use of English in `why` output (`#3280`)__

    [Ben](mailto:rockingskier@gmail.com) - Tue, 2 May 2017 12:11:50 +0200


* __Add tests for global command (`#3238`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Tue, 2 May 2017 10:30:20 +0100



* __Resolve Git dependencies offline if tarball is available. (`#3000`)__

    [Raymond Wang](mailto:me@raymond.sh) - Mon, 1 May 2017 20:00:56 +0100

    When running yarn offline, Git dependencies get trapped in
    hasHTTPCapabiity
    even though resolveOverHTTP defaults to returning
    the tarball. This change
    allows us to bypass that step altogether
    if the tarball already exists.


* __add some tests for link/unlink command (`#3293`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Mon, 1 May 2017 17:18:28 +0100


* __remove duplication in __tests__/commands/pack.js (`#3291`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Mon, 1 May 2017 17:10:45 +0100



* __Clean Homebrew Git repo before committing. Fixes `#3275`__

    [Daniel Lo Nigro](mailto:daniel@dan.cx) - Sat, 29 Apr 2017 17:05:33 -0700



* __`pack`: include contents of directories in `files` field (`#3175`)__

    [Joseph Frazier](mailto:1212jtraceur@gmail.com) - Fri, 28 Apr 2017 17:41:51 +0100



* __extract the reporter out of integrity checker (`#3248`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Wed, 26 Apr 2017 17:48:29 +0100




* __Adding verbose output for config file search (`#3236`)__

    [Dennis Webb](mailto:dennis@bluesentryit.com) - Wed, 26 Apr 2017 16:19:00 +0100



* __use close instead of finish event for file copy completion (`#3234`)__

    [Daniel Pihlstrom](mailto:sciolist.se@gmail.com) - Wed, 26 Apr 2017 16:17:24 +0100

    Windows Defender updates timestamps on files immediately after a write stream
    closes. Moving utimes update to after the file has closed corrects this issue.

* __Fix a couple of lint warnings for unused variables (`#3232`)__

    [Lukas Spieß](mailto:lumaxis@users.noreply.github.com) - Wed, 26 Apr 2017 16:15:26 +0100



* __Add .yarnrc env config option (`#3218`)__

    [Sebastian McKenzie](mailto:kittens@users.noreply.github.com) - Wed, 26 Apr 2017 16:12:25 +0100



* __Fix typo: specifally -&gt; specifically (`#3246`)__

    [Joseph Frazier](mailto:1212jtraceur@gmail.com) - Wed, 26 Apr 2017 15:57:50 +0100



* __Change `use_winpty` logic in bin/yarn to just look at YARN_FORCE_WINPTY in environment (`#3245`)__

    [mikew](mailto:wyatt.mike@gmail.com) - Wed, 26 Apr 2017 15:57:30 +0100



* __Fix local tarball file resolution (`#3221`)__

    [Maël Nison](mailto:nison.mael@gmail.com) - Wed, 26 Apr 2017 15:51:28 +0100



* __Fixes for running with artifactory 4.14.1 (`#3172`)__

    [Rogério Chaves](mailto:rogeriochaves@users.noreply.github.com) - Tue, 25 Apr 2017 16:04:09 +0100

    * Add fallback vdn header for repositories that do not support it

    * Add auth even if registry url is https and archive url is http


* __When in flat mode don&`#39`;t add unused dependencies - fixes `#2781` (`#3251`)__

    [Sebastian McKenzie](mailto:kittens@users.noreply.github.com) - Tue, 25 Apr 2017 12:06:38 +0100


* __Move integrity artifacts tracking to separate method - fixes `#3247` (`#3250`)__

    [Sebastian McKenzie](mailto:kittens@users.noreply.github.com) - Tue, 25 Apr 2017 12:06:06 +0100



* __Ref `#2165` - file-resolver should invalidate cache with a new hash (`#2860`)__

    [Matt Traynham](mailto:skitch920@gmail.com) - Mon, 24 Apr 2017 22:31:45 +0100

    * file-resolver should invalidate cache with a new hash everytime

    * Add/update tests for file protocol cache busting with force flag

    * Fixing cache test and adding comment on size of cache directory.


* __Fix global module executable path on Windows (`#3233`)__

    [Daniel Lo Nigro](mailto:daniel@dan.cx) - Mon, 24 Apr 2017 10:56:39 +0100



* __rename skipIntegrity in skipIntegrityCheck (`#3239`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Mon, 24 Apr 2017 10:48:40 +0100



* __Use npm&`#39`;s node-gyp if available, otherwise automatically install node-gyp (`#3240`)__

    [Daniel Lo Nigro](mailto:daniel@dan.cx) - Mon, 24 Apr 2017 10:44:48 +0100

    * Attempt to install node-gyp if it&`#39`;s required but missing

    * Try to use node-gyp version from npm

    * Trailing commas


* __feat(Upgrade): add scope flag to the upgrade command (`#3190`)__

    [Joge97](mailto:Joge97@users.noreply.github.com) - Mon, 24 Apr 2017 08:53:16 +0200


* __accept 1ms difference in filedates as equal on windows (`#3235`)__

    [Daniel Pihlstrom](mailto:sciolist.se@gmail.com) - Sun, 23 Apr 2017 19:03:44 -0700

    a nodejs issue causes certain dates to be off by 1ms after calling utimes
     See: `https://github.com/nodejs/node/pull/12607`

* __Put build artifact tracking in integrity file (`#3224`)__

    [Sebastian McKenzie](mailto:kittens@users.noreply.github.com) - Sat, 22 Apr 2017 16:45:03 +0100

    * Put build artifact tracking in integrity file

    * fix lint


* __fix lint warning (`#3226`)__

    [Vladimir Agafonkin](mailto:agafonkin@gmail.com) - Sat, 22 Apr 2017 16:44:18 +0100



* __Move inquirer code to console reporter (`#3207`)__

    [Rifat Nabi](mailto:to.rifat@gmail.com) - Sat, 22 Apr 2017 15:52:10 +0100

    * Move inquirer code to console reporter

    * Fix double ctrl+c to exit problem


* __partially revert `#2657` to fix add command test (`#3222`)__

    [Vladimir Agafonkin](mailto:agafonkin@gmail.com) - Fri, 21 Apr 2017 21:21:46 +0100



* __Do not test new version with pkg.version (`#3103`)__

    [Michael Heuberger](mailto:michael.heuberger@binarykitchen.com) - Thu, 20 Apr 2017 19:19:38 -0700

    See issue 3011 for details. Leave it to
    npm registry to validate the version
    number.

* __Adds clean-mirror.sh to scripts (`#3179`)__

    [Maël Nison](mailto:nison.mael@gmail.com) - Thu, 20 Apr 2017 19:08:06 -0700



* __Fix `yarn pack` to always include the file in the &`#34`;main&`#34`; field (`#3092`)__

    [Joseph Frazier](mailto:1212jtraceur@gmail.com) - Thu, 20 Apr 2017 17:48:00 -0700

    * Test that `yarn pack` always includes the file in the &`#34`;main&`#34`; field
     This is for compatibility with npm, which [specifies] that:


* __Optimize buildActionsForCopy routine (`#2657`)__

    [Vladimir Agafonkin](mailto:agafonkin@gmail.com) - Thu, 20 Apr 2017 16:20:48 -0700

    * optimize buildActionsForCopy routine

    * more resilient sync in util.fs, add comments


* __Use an alias system instead of camelCase function (`#3101`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Thu, 20 Apr 2017 16:26:59 +0100

    * - move aliases to unsupported aliases
    - tests properly camelised comand
    - tests properly command with hyphen
    - move generation of documentation in src/cli/commands/index.js
    - move every command related stuff in src/cli/commands/index.js
    - tests some corner cases
    - delete every camelCase use in src/cli/commands/index.js and

    src/cli/commands/help.js

    * fix typo and initialize commands in a clearer way


* __add hasWrapper function in clean and remove command (`#3205`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Thu, 20 Apr 2017 11:32:13 +0100



* __Ensure that every command has setFlags and hasWrapper functions (`#3105`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Thu, 20 Apr 2017 11:08:43 +0100

    * ensure that every command has setFlags function

    * ensure that every command has hasWrapper function


* __Hide Activity/Progress Output in JSONReporter with --no-progress Flag (`#3158`)__

    [Alec Merdler](mailto:merdlera@oregonstate.edu) - Thu, 20 Apr 2017 10:59:39 +0100



* __Avoids using Array.prototype.includes since it is not avaialble in node 4. (`#3139`)__

    [Miguel Madero](mailto:mmadero@zenefits.com) - Thu, 20 Apr 2017 10:56:12 +0100

    Fixes `https://github.com/yarnpkg/yarn/issues/3138`

* __Use gunzip-maybe instead of reimplementing (`#2971`)__

    [Victor Noël](mailto:victornoel@users.noreply.github.com) - Tue, 18 Apr 2017 17:05:37 +0100



* __Better match npm&`#39`;s SCP vs SSH URL heuristic (`#3147`)__

    [Kornel](mailto:kornel@geekhood.net) - Tue, 18 Apr 2017 17:02:32 +0100

    Fixes `#3146`

* __Fix typo: inlude -&gt; include (`#3171`)__

    [Joseph Frazier](mailto:1212jtraceur@gmail.com) - Tue, 18 Apr 2017 16:37:40 +0100



* __Fix typo: definently -&gt; definitely (`#3173`)__

    [Joseph Frazier](mailto:1212jtraceur@gmail.com) - Tue, 18 Apr 2017 16:37:16 +0100



* __Fix bug when cannot set a config value to empty string (`#3018`)__

    [Igor Redchuk](mailto:redchuk@gmail.com) - Tue, 18 Apr 2017 11:52:34 +0100

    * Fixes regression introduced in PR `#2440`
    * Related to `#2434`


* __Automatically update Homebrew package when new versions are released (`#3083`)__

    [Daniel Lo Nigro](mailto:daniel@dan.cx) - Thu, 13 Apr 2017 08:19:09 -0700

    Closes `#2841`


* __Fix resolver incorrect lockfile (issue `#2629`) (`#3106`)__

    [Konstantin Raev](mailto:bestander@gmail.com) - Wed, 12 Apr 2017 18:28:42 +0100

    * wip fixing resolver when lockfile has incorrect semver entries

    * Fixes incorrect entries in lockfiles
     Fixes `#2629`.
    If lockfile pattern does not match a version it will be ignored
    and re-resolved


* __supported smaller package metadata API (`#3112`)__

    [Konstantin Raev](mailto:bestander@gmail.com) - Wed, 12 Apr 2017 18:16:30 +0100

    * supported smaller package metadata according to
    `https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md`


* __Added --ignore-scripts flag to integrity check (`#3094`)__

    [Konstantin Raev](mailto:bestander@gmail.com) - Wed, 12 Apr 2017 18:12:13 +0100

    --ignore-scripts affects the underlying node_modules and should be factored in
    integrity check

* __Fixed concurrent unpacks into the same folder (`#3090`)__

    [Konstantin Raev](mailto:bestander@gmail.com) - Mon, 10 Apr 2017 22:53:35 +0100

    This is a mitigation for issue `#2629`.
    In some cases two different packages
    could end up unpacking into the same cache folder.
    Example
    `https://github.com/yarnpkg/yarn/issues/2629#issuecomment-282745896,` package
    typescript is downloaded twice because yarn.lock has inconsistent entries.


* __Reduce complexity of src/cli/index.js (`#2887`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Mon, 10 Apr 2017 17:43:24 +0100


* __add tests for cache commands (`#2956`)__

    [Simon Vocella](mailto:voxsim@gmail.com) - Mon, 10 Apr 2017 16:04:47 +0100



* __Remove Roadrunner (`#3079`)__

    [Daniel Lo Nigro](mailto:daniel@dan.cx) - Sat, 8 Apr 2017 14:55:11 -0700



* __Use standalone .js bundle in dist tarball rather than individual JS files (`#3030`)__

    [Daniel Lo Nigro](mailto:daniel@dan.cx) - Sat, 8 Apr 2017 14:40:19 -0700

    Instead of including all the raw JS files in the dist tarball, just use the
    single Yarn JS file that&`#39`;s built as part of the build, along with a few other
    files that are required. This significantly reduces the number of files in the
    tarball:


     Performance is very slightly faster when using `v8-compile-cache` along with
    the bundled file, but it&`#39`;s not extremely significant (`yarn --version` went
    from 0.19s to 0.14s on my BuyVM server). The difference might be bigger on
    servers with slower disks (HDD) or with more overloaded servers.
     I also deleted the `build-dist.ps1` file because we _should_ be able to assume
    that Bash is available on Windows, particularly if Git is installed (as it
    comes with Git Bash). I need to verify that this works on AppVeyor.

* __Make it log &`#34`;email&`#34`; instead of &`#34`;username&`#34`; (`#3073`)__

    [Jamen Marz](mailto:jamenmarz+gh@gmail.com) - Fri, 7 Apr 2017 19:07:38 +0100



* __Remove the dependency on the &`#34`;rc&`#34`; module (`#3063`)__

    [Maël Nison](mailto:nison.mael@gmail.com) - Fri, 7 Apr 2017 15:28:55 +0100

  

* __Fixes integrity check for --production flag (`#3067`)__

    [Konstantin Raev](mailto:bestander@gmail.com) - Fri, 7 Apr 2017 15:05:11 +0100


* __Fix missing subdeps in production install when those are present in devDependencies list (`#2921`)__

    [blexrob](mailto:rob@b-lex.nl) - Fri, 7 Apr 2017 12:41:11 +0100

    * Test for install skipping subdependencies when those are named in root
    devDependencies

    * Add &`#39`;incompatible&`#39`; flag to references, use that to ignore incompatible
    packages instead of faulty inherit logic. Fixes `#2819`

    * Unconditionally mark packages as ignored, hoister now fully corrects
    transitive uses


* __Checks that the webpack builds are working properly (`#3064`)__

    [Maël Nison](mailto:nison.mael@gmail.com) - Fri, 7 Apr 2017 12:27:15 +0100



* __Ability to opt-out of offline mirror (`#3009`)__

    [Dan Harper](mailto:intouch@danharper.me) - Fri, 7 Apr 2017 11:32:01 +0100

    Configs are merged with configs in parent directories, so currently if a
    .yarnrc in a parent directory enables the offline mirror, all projects in child
    directories would also use the offline mirror.
     This commit allows a child directory to opt-out of the offline mirror in their
    own .yarnrc with `yarn-offline-mirror false`.
     Previously if you specified `false` you&`#39`;d get an exception as false is parsed
    as boolean but it expects a string.

* __Providing override for CHILD_CONCURRENCY via ENV (`#3032`)__

    [Hari Juturu](mailto:juturu@live.com) - Thu, 6 Apr 2017 23:28:28 +0100

  

* __Supports public and private git repos when using shorted repo syntax (`#2992`)__

    [The Dumb Terminal](mailto:thedumbterminal@users.noreply.github.com) - Thu, 6 Apr 2017 17:05:24 +0100

    * Now supports public and private shortened git repos

    * added tests for new method




