### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-jsx-a11y to 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jest": "20.0.1",
     "eslint-plugin-jsdoc": "3.1.0",
-    "eslint-plugin-jsx-a11y": "5.0.2",
+    "eslint-plugin-jsx-a11y": "5.0.3",
     "eslint-plugin-prettier": "2.0.1",
     "eslint-plugin-react": "7.0.1",
     "eslint-plugin-security": "1.3.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-jsx-a11y`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-jsx-a11y from `5.0.2` to `5.0.3`

#### Changelog:

#### Version 5.0.3
for explicit imports in `v5.0.2`

