### PR TITLE
[Doppins] Upgrade dependency jest to 20.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "husky": "0.13.3",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
-    "jest": "20.0.2",
+    "jest": "20.0.3",
     "jest-cli": "20.0.1",
     "jest-css-modules": "1.1.0",
     "json-loader": "0.5.4",


### PR DESCRIPTION
Hi!

A new version was just released of `jest`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded jest from `20.0.1` to `20.0.2`

