### PR TITLE
[Doppins] Upgrade dependency offline-plugin to 4.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "jest-cli": "20.0.1",
     "jest-css-modules": "1.1.0",
     "json-loader": "0.5.4",
-    "offline-plugin": "4.8.0",
+    "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
     "prettier": "1.3.1",


### PR DESCRIPTION
Hi!

A new version was just released of `offline-plugin`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded offline-plugin from `4.8.0` to `4.8.1`

