### PR TITLE
[Doppins] Upgrade dependency style-loader to 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.2.0",
-    "style-loader": "0.17.0",
+    "style-loader": "0.18.0",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",


### PR DESCRIPTION
Hi!

A new version was just released of `style-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded style-loader from `0.17.0` to `0.18.0`

#### Changelog:

#### Version 0.18.0
<a name="0.18.0"></a>
# 0.18.0 (`https://github.com/webpack/style-loader/compare/v0.17.0...v0.18.0`) (2017-05-22)


### Bug Fixes

* stringify the options.transform request (`#230`](`https://github.com/webpack/style-loader/issues/230`)) ([5888095 (`https://github.com/webpack/style-loader/commit/5888095`))


### Features

* add options validation (`#224`](`https://github.com/webpack/style-loader/issues/224`)) ([4b6b70d (`https://github.com/webpack/style-loader/commit/4b6b70d`))


