### PR TITLE
[Doppins] Upgrade dependency webpack to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "2.5.1",
+    "webpack": "2.6.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.4"


### PR DESCRIPTION
Hi!

A new version was just released of `webpack`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded webpack from `2.5.1` to `2.6.0`

