### PR TITLE
[Doppins] Upgrade dependency sinon to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "2.3.0",
+    "sinon": "2.3.1",
     "style-loader": "0.18.0",
     "stylint": "1.5.9",
     "stylus": "0.54.5",


### PR DESCRIPTION
Hi!

A new version was just released of `sinon`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sinon from `2.3.0` to `2.3.1`

