### PR TITLE
[Doppins] Upgrade dependency webpack to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.7.1",
+    "webpack": "3.8.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.10.0",
+    "webpack": "4.10.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.20.2",
+    "webpack": "4.21.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.10.0",
+    "webpack": "3.11.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.9.0",
+    "webpack": "4.9.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.0.1",
+    "webpack": "4.1.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.16.3",
+    "webpack": "4.16.4",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.16.1",
+    "webpack": "4.16.2",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.17.3",
+    "webpack": "4.18.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.5.3",
+    "webpack": "3.5.4",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.5.5",
+    "webpack": "3.5.6",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.8.1",
+    "webpack": "3.9.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.9.1",
+    "webpack": "3.10.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.7.0",
+    "webpack": "4.8.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.5.1",
+    "webpack": "3.5.2",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.16.2",
+    "webpack": "4.16.3",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.17.1",
+    "webpack": "4.17.2",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.18.0",
+    "webpack": "4.18.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.2.0",
+    "webpack": "4.3.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.9.1",
+    "webpack": "4.10.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "2.6.1",
+    "webpack": "3.5.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.10.1",
+    "webpack": "4.10.2",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.5.0",
+    "webpack": "4.6.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.14.0",
+    "webpack": "4.16.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.6.0",
+    "webpack": "3.7.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.12.2",
+    "webpack": "4.13.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.17.0",
+    "webpack": "4.17.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.8.1",
+    "webpack": "4.8.2",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.7.0",
+    "webpack": "3.7.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.6.0",
+    "webpack": "4.7.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.19.1",
+    "webpack": "4.20.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.5.6",
+    "webpack": "3.6.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.19.0",
+    "webpack": "4.19.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.1.0",
+    "webpack": "4.1.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.10.2",
+    "webpack": "4.11.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.13.0",
+    "webpack": "4.14.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.8.2",
+    "webpack": "4.9.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.4.1",
+    "webpack": "4.5.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.11.1",
+    "webpack": "4.12.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.9.0",
+    "webpack": "3.9.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.5.2",
+    "webpack": "3.5.3",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.0.0",
+    "webpack": "4.0.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.18.1",
+    "webpack": "4.19.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.20.0",
+    "webpack": "4.20.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.12.1",
+    "webpack": "4.12.2",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "2.6.0",
+    "webpack": "2.6.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.5.0",
+    "webpack": "3.5.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.16.5",
+    "webpack": "4.17.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.4.0",
+    "webpack": "4.4.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.8.0",
+    "webpack": "4.8.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.12.0",
+    "webpack": "4.12.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.8.0",
+    "webpack": "3.8.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.17.2",
+    "webpack": "4.17.3",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.16.4",
+    "webpack": "4.16.5",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.11.0",
+    "webpack": "4.0.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.3.0",
+    "webpack": "4.4.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.20.1",
+    "webpack": "4.20.2",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.11.0",
+    "webpack": "4.11.1",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "4.1.1",
+    "webpack": "4.2.0",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",
     "svgo": "0.7.2",
-    "webpack": "3.5.4",
+    "webpack": "3.5.5",
     "webpack-dev-server": "2.4.5",
     "worker-loader": "0.8.0",
     "yarn": "0.24.5"


### PR DESCRIPTION
Hi!

A new version was just released of `webpack`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded webpack from `2.6.0` to `2.6.1`

