### PR TITLE
[Doppins] Upgrade dependency css-loader to 0.28.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.11",
+    "css-loader": "1.0.0",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.3",
+    "css-loader": "0.28.4",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "1.0.0",
+    "css-loader": "1.0.1",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.5",
+    "css-loader": "0.28.6",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.9",
+    "css-loader": "0.28.10",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.6",
+    "css-loader": "0.28.7",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.10",
+    "css-loader": "0.28.11",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "2.1.0",
+    "css-loader": "2.1.1",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "2.0.2",
+    "css-loader": "2.1.0",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.2",
+    "css-loader": "0.28.3",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.4",
+    "css-loader": "0.28.5",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.7",
+    "css-loader": "0.28.8",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "2.0.0",
+    "css-loader": "2.0.1",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "2.0.1",
+    "css-loader": "2.0.2",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "1.0.1",
+    "css-loader": "2.0.0",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "codecov": "2.2.0",
-    "css-loader": "0.28.8",
+    "css-loader": "0.28.9",
     "enzyme": "2.8.1",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",


### PR DESCRIPTION
Hi!

A new version was just released of `css-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded css-loader from `0.28.2` to `0.28.3`

