### PR TITLE
[Doppins] Upgrade dependency flow-bin to 0.47.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.68.0",
+    "flow-bin": "0.69.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.90.0",
+    "flow-bin": "0.91.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.56.0",
+    "flow-bin": "0.57.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.74.0",
+    "flow-bin": "0.75.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.96.0",
+    "flow-bin": "0.97.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.92.1",
+    "flow-bin": "0.93.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.85.0",
+    "flow-bin": "0.86.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.79.1",
+    "flow-bin": "0.80.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.79.0",
+    "flow-bin": "0.79.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.54.1",
+    "flow-bin": "0.55.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.57.2",
+    "flow-bin": "0.57.3",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.88.0",
+    "flow-bin": "0.89.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.94.0",
+    "flow-bin": "0.95.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.63.1",
+    "flow-bin": "0.64.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.53.0",
+    "flow-bin": "0.53.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.64.0",
+    "flow-bin": "0.65.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.84.0",
+    "flow-bin": "0.85.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.58.0",
+    "flow-bin": "0.59.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.95.1",
+    "flow-bin": "0.96.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.98.0",
+    "flow-bin": "0.98.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.59.0",
+    "flow-bin": "0.60.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.70.0",
+    "flow-bin": "0.71.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.52.0",
+    "flow-bin": "0.53.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.57.1",
+    "flow-bin": "0.57.2",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.60.0",
+    "flow-bin": "0.60.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.99.0",
+    "flow-bin": "0.99.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.63.0",
+    "flow-bin": "0.63.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.92.0",
+    "flow-bin": "0.92.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.93.0",
+    "flow-bin": "0.94.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.76.0",
+    "flow-bin": "0.77.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.73.0",
+    "flow-bin": "0.74.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.97.0",
+    "flow-bin": "0.98.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.75.0",
+    "flow-bin": "0.76.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.78.0",
+    "flow-bin": "0.79.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.95.0",
+    "flow-bin": "0.95.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.72.0",
+    "flow-bin": "0.73.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.77.0",
+    "flow-bin": "0.78.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.62.0",
+    "flow-bin": "0.63.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.80.0",
+    "flow-bin": "0.81.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.71.0",
+    "flow-bin": "0.72.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.83.0",
+    "flow-bin": "0.84.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.91.0",
+    "flow-bin": "0.92.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.55.0",
+    "flow-bin": "0.56.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.53.1",
+    "flow-bin": "0.54.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.57.3",
+    "flow-bin": "0.58.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.47.0",
+    "flow-bin": "0.52.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.99.1",
+    "flow-bin": "0.100.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.69.0",
+    "flow-bin": "0.70.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.81.0",
+    "flow-bin": "0.82.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.66.0",
+    "flow-bin": "0.67.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.89.0",
+    "flow-bin": "0.90.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.87.0",
+    "flow-bin": "0.88.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.65.0",
+    "flow-bin": "0.66.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.46.0",
+    "flow-bin": "0.47.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.67.1",
+    "flow-bin": "0.68.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.86.0",
+    "flow-bin": "0.87.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.82.0",
+    "flow-bin": "0.83.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.98.1",
+    "flow-bin": "0.99.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.61.0",
+    "flow-bin": "0.62.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.60.1",
+    "flow-bin": "0.61.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.11.1",
-    "flow-bin": "0.54.0",
+    "flow-bin": "0.54.1",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",


### PR DESCRIPTION
Hi!

A new version was just released of `flow-bin`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded flow-bin from `0.46.0` to `0.47.0`

