### PR TITLE
[Doppins] Upgrade dependency sinon to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.7",
+    "sinon": "5.0.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.3.0",
+    "sinon": "4.4.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "6.1.0",
+    "sinon": "6.1.3",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "3.1.0",
+    "sinon": "3.2.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "6.0.0",
+    "sinon": "6.0.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.1.2",
+    "sinon": "4.1.3",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.6",
+    "sinon": "5.0.7",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "6.1.4",
+    "sinon": "6.1.5",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "2.3.2",
+    "sinon": "3.0.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.5",
+    "sinon": "4.4.6",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.1.3",
+    "sinon": "4.1.4",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.10",
+    "sinon": "5.1.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "6.1.5",
+    "sinon": "6.1.6",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "3.2.1",
+    "sinon": "3.3.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.5",
+    "sinon": "5.0.6",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.1",
+    "sinon": "5.0.2",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "6.1.3",
+    "sinon": "6.1.4",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.6",
+    "sinon": "4.4.7",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.7",
+    "sinon": "5.0.8",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.3",
+    "sinon": "5.0.4",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.1",
+    "sinon": "4.4.2",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.5.0",
+    "sinon": "5.0.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.0.1",
+    "sinon": "4.0.2",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.1.5",
+    "sinon": "4.1.6",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.1.6",
+    "sinon": "4.2.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.8",
+    "sinon": "4.4.9",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.2.1",
+    "sinon": "4.2.2",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "3.3.0",
+    "sinon": "4.0.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.10",
+    "sinon": "4.4.9",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.2.2",
+    "sinon": "4.2.3",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.8",
+    "sinon": "5.0.9",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.9",
+    "sinon": "4.5.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.9",
+    "sinon": "4.4.10",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "3.0.0",
+    "sinon": "3.1.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.1.1",
+    "sinon": "4.1.2",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.1.4",
+    "sinon": "4.1.5",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.0",
+    "sinon": "4.4.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.0",
+    "sinon": "4.4.8",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "3.2.0",
+    "sinon": "3.2.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.4",
+    "sinon": "5.0.5",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.1.0",
+    "sinon": "4.1.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.1.1",
+    "sinon": "6.0.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "6.0.1",
+    "sinon": "6.1.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "6.1.6",
+    "sinon": "6.2.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.2",
+    "sinon": "4.4.3",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.9",
+    "sinon": "5.0.10",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.0.0",
+    "sinon": "4.0.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.0.2",
+    "sinon": "4.1.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.3",
+    "sinon": "4.4.4",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.2.0",
+    "sinon": "4.2.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.2.3",
+    "sinon": "4.3.0",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "4.4.4",
+    "sinon": "4.4.5",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.0.2",
+    "sinon": "5.0.3",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "2.3.1",
+    "sinon": "2.3.2",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
-    "sinon": "5.1.0",
+    "sinon": "5.1.1",
     "style-loader": "0.18.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",


### PR DESCRIPTION
Hi!

A new version was just released of `sinon`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sinon from `2.3.1` to `2.3.2`

