### PR TITLE
[Doppins] Upgrade dependency husky to 0.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "0.13.3",
+    "husky": "0.13.4",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.2.0",
+    "husky": "1.2.1",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.1.4",
+    "husky": "1.2.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "2.3.0",
+    "husky": "2.4.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.2.1",
+    "husky": "1.3.1",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "2.0.0",
+    "husky": "2.1.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.3.0",
+    "husky": "1.2.1",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "2.2.0",
+    "husky": "2.3.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.1.1",
+    "husky": "1.1.2",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.2.1",
+    "husky": "1.3.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.3.1",
+    "husky": "2.0.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.1.0",
+    "husky": "1.1.1",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "2.1.0",
+    "husky": "2.2.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.1.3",
+    "husky": "1.1.4",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "0.13.4",
+    "husky": "1.0.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.0.1",
+    "husky": "1.1.0",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.1.2",
+    "husky": "1.1.3",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",
     "html-webpack-plugin": "2.28.0",
-    "husky": "1.0.0",
+    "husky": "1.0.1",
     "img-loader": "^2.0.0",
     "istanbul": "0.4.5",
     "jest": "20.0.4",


### PR DESCRIPTION
Hi!

A new version was just released of `husky`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded husky from `0.13.3` to `0.13.4`

