### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-flowtype to 2.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.4.1",
+    "eslint-plugin-flowtype": "3.4.2",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.46.2",
+    "eslint-plugin-flowtype": "2.46.3",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.8.2",
+    "eslint-plugin-flowtype": "3.9.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.36.0",
+    "eslint-plugin-flowtype": "2.37.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.0.0",
+    "eslint-plugin-flowtype": "3.1.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.35.1",
+    "eslint-plugin-flowtype": "2.36.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.1.1",
+    "eslint-plugin-flowtype": "3.1.2",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.2.1",
+    "eslint-plugin-flowtype": "3.2.2",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.6.0",
+    "eslint-plugin-flowtype": "3.6.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.1.3",
+    "eslint-plugin-flowtype": "3.1.4",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.46.1",
+    "eslint-plugin-flowtype": "2.46.2",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.3.0",
+    "eslint-plugin-flowtype": "3.4.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.1.2",
+    "eslint-plugin-flowtype": "3.1.3",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.9.0",
+    "eslint-plugin-flowtype": "3.9.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.45.0",
+    "eslint-plugin-flowtype": "2.46.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.49.0",
+    "eslint-plugin-flowtype": "2.49.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.47.1",
+    "eslint-plugin-flowtype": "2.48.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.42.0",
+    "eslint-plugin-flowtype": "2.43.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.38.0",
+    "eslint-plugin-flowtype": "2.39.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.39.1",
+    "eslint-plugin-flowtype": "2.40.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.5.1",
+    "eslint-plugin-flowtype": "3.6.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.46.0",
+    "eslint-plugin-flowtype": "2.46.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.7.0",
+    "eslint-plugin-flowtype": "3.8.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.49.2",
+    "eslint-plugin-flowtype": "2.49.3",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.48.0",
+    "eslint-plugin-flowtype": "2.49.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.1.0",
+    "eslint-plugin-flowtype": "3.1.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.8.0",
+    "eslint-plugin-flowtype": "3.8.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.49.1",
+    "eslint-plugin-flowtype": "2.49.2",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.40.0",
+    "eslint-plugin-flowtype": "2.40.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.4.2",
+    "eslint-plugin-flowtype": "3.5.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.8.1",
+    "eslint-plugin-flowtype": "3.8.2",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.2.0",
+    "eslint-plugin-flowtype": "3.2.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.50.3",
+    "eslint-plugin-flowtype": "3.0.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.43.0",
+    "eslint-plugin-flowtype": "2.44.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.50.0",
+    "eslint-plugin-flowtype": "2.50.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.41.0",
+    "eslint-plugin-flowtype": "2.41.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.33.0",
+    "eslint-plugin-flowtype": "2.34.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.41.1",
+    "eslint-plugin-flowtype": "2.42.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.44.0",
+    "eslint-plugin-flowtype": "2.45.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.1.4",
+    "eslint-plugin-flowtype": "3.2.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.46.3",
+    "eslint-plugin-flowtype": "2.47.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.6.1",
+    "eslint-plugin-flowtype": "3.7.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.50.2",
+    "eslint-plugin-flowtype": "2.50.3",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.50.1",
+    "eslint-plugin-flowtype": "2.50.2",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.49.3",
+    "eslint-plugin-flowtype": "2.50.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.39.0",
+    "eslint-plugin-flowtype": "2.39.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.2.2",
+    "eslint-plugin-flowtype": "3.3.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.40.1",
+    "eslint-plugin-flowtype": "2.41.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.5.0",
+    "eslint-plugin-flowtype": "3.5.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.34.0",
+    "eslint-plugin-flowtype": "2.35.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "3.4.0",
+    "eslint-plugin-flowtype": "3.4.1",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "eslint": "3.19.0",
     "eslint-loader": "1.7.1",
     "eslint-plugin-eslint-comments": "1.0.0",
-    "eslint-plugin-flowtype": "2.37.0",
+    "eslint-plugin-flowtype": "2.38.0",
     "eslint-plugin-fp": "2.3.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jest": "20.0.3",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-flowtype`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-flowtype from `2.33.0` to `2.34.0`

#### Changelog:

#### Version 2.34.0
<a name"2.34.0"></a>
## 2.34.0 (2017-05-30)


#### Features

* update `looksLikeFlowFileAnnotation` regex to match only `@flow` (`#233`) (42328cd8 (`https://github.com/gajus/eslint-plugin-flowtype/commit/42328cd8`))



