### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-import to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.12.0",
+    "eslint-plugin-import": "2.13.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-import": "2.15.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.17.2",
+    "eslint-plugin-import": "2.17.3",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.17.1",
+    "eslint-plugin-import": "2.17.2",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.15.0",
+    "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.11.0",
+    "eslint-plugin-import": "2.12.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.13.0",
+    "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.17.0",
+    "eslint-plugin-import": "2.17.1",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.10.0",
+    "eslint-plugin-import": "2.11.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.3.0",
+    "eslint-plugin-import": "2.4.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.16.0",
+    "eslint-plugin-import": "2.17.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.8.0",
+    "eslint-plugin-import": "2.9.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.9.0",
+    "eslint-plugin-import": "2.10.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-eslint-comments": "1.0.0",
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-fp": "2.3.0",
-    "eslint-plugin-import": "2.4.0",
+    "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jest": "20.0.3",
     "eslint-plugin-jsdoc": "3.1.0",
     "eslint-plugin-jsx-a11y": "5.0.3",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-import`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-import from `2.3.0` to `2.4.0`

