### PR TITLE
[Doppins] Upgrade dependency prettier to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.11.1",
+    "prettier": "1.12.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.15.3",
+    "prettier": "1.16.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.4",
+    "prettier": "1.13.5",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.9.1",
+    "prettier": "1.9.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.9.0",
+    "prettier": "1.9.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.7.3",
+    "prettier": "1.7.4",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.7.0",
+    "prettier": "1.7.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.10.1",
+    "prettier": "1.10.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.16.2",
+    "prettier": "1.16.3",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.3.1",
+    "prettier": "1.4.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.14.0",
+    "prettier": "1.14.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.16.1",
+    "prettier": "1.16.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.16.4",
+    "prettier": "1.17.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.7",
+    "prettier": "1.14.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.16.0",
+    "prettier": "1.16.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.15.0",
+    "prettier": "1.15.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.14.1",
+    "prettier": "1.14.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.8.1",
+    "prettier": "1.8.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.1",
+    "prettier": "1.13.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.7.2",
+    "prettier": "1.7.3",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.4.0",
+    "prettier": "1.4.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.10.2",
+    "prettier": "1.11.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.5.3",
+    "prettier": "1.6.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.14.3",
+    "prettier": "1.15.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.5",
+    "prettier": "1.13.6",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.17.0",
+    "prettier": "1.17.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.4.1",
+    "prettier": "1.4.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.8.0",
+    "prettier": "1.8.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.0",
+    "prettier": "1.13.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.16.3",
+    "prettier": "1.16.4",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.6",
+    "prettier": "1.13.7",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.10.0",
+    "prettier": "1.10.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.11.0",
+    "prettier": "1.11.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.7.1",
+    "prettier": "1.7.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.2",
+    "prettier": "1.13.3",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.13.3",
+    "prettier": "1.13.4",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.15.2",
+    "prettier": "1.15.3",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.12.1",
+    "prettier": "1.13.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.9.2",
+    "prettier": "1.10.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.6.0",
+    "prettier": "1.6.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.15.1",
+    "prettier": "1.15.2",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.7.4",
+    "prettier": "1.8.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.4.2",
+    "prettier": "1.5.3",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.6.1",
+    "prettier": "1.7.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.12.0",
+    "prettier": "1.12.1",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.8.2",
+    "prettier": "1.9.0",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "offline-plugin": "4.8.1",
     "postcss-loader": "2.0.5",
     "postcss-svgo": "2.1.6",
-    "prettier": "1.14.2",
+    "prettier": "1.14.3",
     "react-addons-test-utils": "15.5.1",
     "react-hot-loader": "3.0.0-beta.7",
     "react-test-renderer": "15.5.4",


### PR DESCRIPTION
Hi!

A new version was just released of `prettier`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded prettier from `1.3.1` to `1.4.0`

