### PR TITLE
[Doppins] Upgrade dependency file-loader to 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "0.11.2",
+    "file-loader": "1.1.0",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.4",
+    "file-loader": "1.1.5",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.0",
+    "file-loader": "1.1.1",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.7",
+    "file-loader": "1.1.8",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.10",
+    "file-loader": "1.1.11",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.5",
+    "file-loader": "1.1.6",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.6",
+    "file-loader": "1.1.7",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.9",
+    "file-loader": "1.1.10",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.8",
+    "file-loader": "1.1.9",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.2",
+    "file-loader": "1.1.3",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.3",
+    "file-loader": "1.1.4",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "0.11.1",
+    "file-loader": "0.11.2",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "eslint-plugin-security": "1.3.0",
     "eslint-plugin-unicorn": "2.1.1",
     "favicons-webpack-plugin": "0.0.7",
-    "file-loader": "1.1.1",
+    "file-loader": "1.1.2",
     "flow-bin": "0.46.0",
     "flow-coverage-report": "0.3.0",
     "gh-pages": "1.0.0",


### PR DESCRIPTION
Hi!

A new version was just released of `file-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded file-loader from `0.11.1` to `0.11.2`

