### PR TITLE
[Doppins] Upgrade dependency style-loader to 0.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.19.0",
+    "style-loader": "0.19.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.22.1",
+    "style-loader": "0.23.0",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.18.2",
+    "style-loader": "0.19.0",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.18.1",
+    "style-loader": "0.18.2",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.19.1",
+    "style-loader": "0.20.0",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.20.1",
+    "style-loader": "0.20.2",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.20.0",
+    "style-loader": "0.20.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.20.3",
+    "style-loader": "0.21.0",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.22.0",
+    "style-loader": "0.22.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.21.0",
+    "style-loader": "0.22.0",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.20.2",
+    "style-loader": "0.20.3",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-test-renderer": "15.5.4",
     "redux-mock-store": "1.2.3",
     "sinon": "2.3.1",
-    "style-loader": "0.23.0",
+    "style-loader": "0.23.1",
     "stylint": "1.5.9",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.1",


### PR DESCRIPTION
Hi!

A new version was just released of `style-loader`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded style-loader from `0.18.1` to `0.18.2`

#### Changelog:

#### Version 0.18.2
<a name="0.18.2"></a>
## 0.18.2 (`https://github.com/webpack/style-loader/compare/v0.18.1...v0.18.2`) (2017-06-05)


### Bug Fixes

* **url:** use `loaderUtils.stringifyRequest` to avoid invalidating hashes due to absolute paths (`#242`](`https://github.com/webpack/style-loader/issues/242`)) ([97508ec (`https://github.com/webpack/style-loader/commit/97508ec`))
* Add `null` check to `removeStyleElement` (`#245`](`https://github.com/webpack/style-loader/issues/245`)) ([0a4845c (`https://github.com/webpack/style-loader/commit/0a4845c`))


